### PR TITLE
Update xdebug version and remove version restrictions for php7.4

### DIFF
--- a/include/pecl_xdebug.sh
+++ b/include/pecl_xdebug.sh
@@ -14,8 +14,8 @@ Install_pecl_xdebug() {
     phpExtensionDir=$(${php_install_dir}/bin/php-config --extension-dir)
     PHP_detail_ver=$(${php_install_dir}/bin/php-config --version)
     PHP_main_ver=${PHP_detail_ver%.*}
-    if [[ "${PHP_main_ver}" =~ ^5.[5-6]$|^7.[0-3]$ ]]; then
-      if [[ "${PHP_main_ver}" =~ ^7.[0-3]$ ]]; then
+    if [[ "${PHP_main_ver}" =~ ^5.[5-6]$|^7.[0-4]$ ]]; then
+      if [[ "${PHP_main_ver}" =~ ^7.[0-4]$ ]]; then
         src_url=https://pecl.php.net/get/xdebug-${xdebug_ver}.tgz && Download_src
         tar xzf xdebug-${xdebug_ver}.tgz
         pushd xdebug-${xdebug_ver} > /dev/null

--- a/versions.txt
+++ b/versions.txt
@@ -83,7 +83,7 @@ yaf_ver=3.0.9
 yar_ver=2.0.7
 swoole_ver=4.4.16
 swoole_oldver=1.10.5
-xdebug_ver=2.9.2
+xdebug_ver=2.9.5
 xdebug_oldver=2.5.5
 
 # Ftp


### PR DESCRIPTION
Everything is fine.

``` shell
PHP 7.4.6 (cli) (built: May 23 2020 22:31:19) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Xdebug v2.9.5, Copyright (c) 2002-2020, by Derick Rethans
```