### PR TITLE
CentOS Stream 8 Install MySQL 8.0 from Source Compiler Error

### DIFF
--- a/include/mysql-8.0.sh
+++ b/include/mysql-8.0.sh
@@ -38,6 +38,8 @@ Install_MySQL80() {
     -DWITH_MYISAM_STORAGE_ENGINE=1 \
     -DENABLED_LOCAL_INFILE=1 \
     -DFORCE_INSOURCE_BUILD=1 \
+    -DCMAKE_C_COMPILER=/usr/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
     -DDEFAULT_CHARSET=utf8mb4
     make -j ${THREAD}
     make install


### PR DESCRIPTION
CentOS Stream 8 Error without the following args.

-DCMAKE_C_COMPILER=/usr/bin/gcc
-DCMAKE_CXX_COMPILER=/usr/bin/g++