### PR TITLE
[fix] Upgrade Apache to 2.4.52 (修复高危漏洞)

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -11,7 +11,7 @@ tomcat9_ver=9.0.55
 tomcat8_ver=8.5.73
 tomcat7_ver=7.0.109
 
-apache_ver=2.4.51
+apache_ver=2.4.52
 pcre_ver=8.45
 apr_ver=1.7.0
 apr_util_ver=1.6.1


### PR DESCRIPTION
[CVE-2021-44224](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44224)
[CVE-2021-44790](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44790)