### PR TITLE
Add a judgment on whether the tomcat-user is set to be unable to log in

### DIFF
--- a/init.d/Tomcat-init
+++ b/init.d/Tomcat-init
@@ -86,7 +86,7 @@ stop() {
 }
 
 user_exists() {
-  if [ "`cat /etc/passwd | grep ftp | cut -d ":" -f7 | cut -d "/" -f4`" = "nologin" ]; then
+  if [ "`cat /etc/passwd | grep www | cut -d ":" -f7 | cut -d "/" -f4`" = "nologin" ]; then
     if id -u $1 >/dev/null 2>&1; then
       echo "1"
     else

--- a/init.d/Tomcat-init
+++ b/init.d/Tomcat-init
@@ -87,8 +87,8 @@ stop() {
 
 user_exists() {
   if id -u $1 >/dev/null 2>&1; then
-	temp=`cat /etc/passwd | grep ^www: | grep nologin$`
-	if [ "${temp: -7}" = "nologin" ]; then
+	islogin=`cat /etc/passwd | grep ^www: | grep nologin$`
+	if [ "${islogin: -7}" = "nologin" ]; then
       echo "0"
     else
       echo "1"	

--- a/init.d/Tomcat-init
+++ b/init.d/Tomcat-init
@@ -86,11 +86,12 @@ stop() {
 }
 
 user_exists() {
-  if [ "`cat /etc/passwd | grep www | cut -d ":" -f7 | cut -d "/" -f4`" = "nologin" ]; then
-    if id -u $1 >/dev/null 2>&1; then
-      echo "1"
-    else
+  if id -u $1 >/dev/null 2>&1; then
+	temp=`cat /etc/passwd | grep ^www: | grep nologin$`
+	if [ "${temp: -7}" = "nologin" ]; then
       echo "0"
+    else
+      echo "1"	
     fi
   else
     echo "0"

--- a/init.d/Tomcat-init
+++ b/init.d/Tomcat-init
@@ -86,8 +86,12 @@ stop() {
 }
 
 user_exists() {
-  if id -u $1 >/dev/null 2>&1; then
-    echo "1"
+  if [ "`cat /etc/passwd | grep ftp | cut -d ":" -f7 | cut -d "/" -f4`" = "nologin" ]; then
+    if id -u $1 >/dev/null 2>&1; then
+      echo "1"
+    else
+      echo "0"
+    fi
   else
     echo "0"
   fi


### PR DESCRIPTION
This change can avoid errors caused by the script's default tomcat user 'www' being created and set to 'nologin'.