### PR TITLE
fix: bump phpredis to 6.0.1 to avoid memory leak

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -90,7 +90,7 @@ pureftpd_ver=1.0.51
 # Redis
 redis_ver=7.2.1
 redis_oldver=6.2.13
-pecl_redis_ver=6.0.0
+pecl_redis_ver=6.0.1
 
 # Memcached
 memcached_ver=1.6.21


### PR DESCRIPTION
https://github.com/phpredis/phpredis/issues/2376