### PR TITLE
fix: openresty and tengine install error

### DIFF
--- a/include/openresty.sh
+++ b/include/openresty.sh
@@ -28,7 +28,7 @@ Install_OpenResty() {
   make -j ${THREAD} && make install
   if [ -e "${openresty_install_dir}/nginx/conf/nginx.conf" ]; then
     popd > /dev/null
-    rm -rf pcre-${pcre_ver}* openssl-${openssl11_ver}* openresty-${openresty_ver}* ${openresty_install_dir}*
+    rm -rf pcre-${pcre_ver}* openssl-${openssl11_ver}* openresty-${openresty_ver}*
     echo "${CSUCCESS}OpenResty installed successfully! ${CEND}"
   else
     rm -rf pcre-${pcre_ver}* openssl-${openssl11_ver}* openresty-${openresty_ver}* ${openresty_install_dir}*

--- a/include/tengine.sh
+++ b/include/tengine.sh
@@ -27,7 +27,7 @@ Install_Tengine() {
   make && make install
   if [ -e "${tengine_install_dir}/conf/nginx.conf" ]; then
     popd > /dev/null
-    rm -rf pcre-${pcre_ver}* openssl-${openssl11_ver}* tengine-${tengine_ver}* rm -rf ${tengine_install_dir}*
+    rm -rf pcre-${pcre_ver}* openssl-${openssl11_ver}* tengine-${tengine_ver}*
     echo "${CSUCCESS}Tengine installed successfully! ${CEND}"
   else
     rm -rf pcre-${pcre_ver}* openssl-${openssl11_ver}* tengine-${tengine_ver}* rm -rf ${tengine_install_dir}*


### PR DESCRIPTION
修复 Openresty 和 Tengine 显示安装成功，但实际安装失败。

自 804cee0 fix:file not remove 引入的问题，
判断安装成功时，清理文件将安装目录也一起删除了。

失败报错如下：
Openresty
make[2]: Leaving directory '/opt/oneinstack/src/openresty-1.21.4.3/build/nginx-1.21.4.3'
make[1]: Leaving directory '/opt/oneinstack/src/openresty-1.21.4.3/build/nginx-1.21.4.3'
mkdir -p /usr/local/openresty/site/lualib /usr/local/openresty/site/pod /usr/local/openresty/site/manifest
ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/local/openresty/bin/openresty
OpenResty installed successfully! 
mv: cannot stat '/usr/local/openresty/nginx/conf/nginx.conf': No such file or directory
/bin/cp: cannot create regular file '/usr/local/openresty/nginx/conf/nginx.conf': No such file or directory
include/openresty.sh: line 56: /usr/local/openresty/nginx/conf/proxy.conf: No such file or directory
sed: can't read /usr/local/openresty/nginx/conf/nginx.conf: No such file or directory
sed: can't read /usr/local/openresty/nginx/conf/nginx.conf: No such file or directory
sed: can't read /usr/local/openresty/nginx/conf/nginx.conf: No such file or directory

Tengine
make[1]: Leaving directory '/opt/oneinstack/src/tengine-3.1.0'
Tengine installed successfully! 
mv: cannot stat '/usr/local/tengine/conf/nginx.conf': No such file or directory
/bin/cp: cannot create regular file '/usr/local/tengine/conf/nginx.conf': No such file or directory
include/tengine.sh: line 55: /usr/local/tengine/conf/proxy.conf: No such file or directory
sed: can't read /usr/local/tengine/conf/nginx.conf: No such file or directory
sed: can't read /usr/local/tengine/conf/nginx.conf: No such file or directory
sed: can't read /usr/local/tengine/conf/nginx.conf: No such file or directory