### PR TITLE
已失效

### DIFF
--- a/include/apache.sh
+++ b/include/apache.sh
@@ -106,6 +106,18 @@ Install_Apache() {
   elif [ "${apache_mpm_option}" == '3' ]; then
     sed -ri 's@^(LoadModule.*mod_mpm_event.so)@#\1@' ${apache_install_dir}/conf/httpd.conf
     sed -i 's@^#LoadModule mpm_worker_module@LoadModule mpm_worker_module@' ${apache_install_dir}/conf/httpd.conf
+    # 验证worker模式是否生效
+    if ! ${apache_install_dir}/bin/httpd -V | grep -q 'worker.c'; then
+      echo "${CFAILURE}Failed to enable worker mode! ${CEND}"
+      exit 1
+    fi
+  fi
+
+  # 安装缺失的apache2工具包
+  if [ "${PM}" == 'apt-get' ]; then
+    apt-get install -y apache2 apache2-utils
+  elif [ "${PM}" == 'yum' ]; then
+    yum install -y httpd-tools
   fi
 
   #logrotate apache log

--- a/include/apache.sh
+++ b/include/apache.sh
@@ -106,6 +106,7 @@ Install_Apache() {
   elif [ "${apache_mpm_option}" == '3' ]; then
     sed -ri 's@^(LoadModule.*mod_mpm_event.so)@#\1@' ${apache_install_dir}/conf/httpd.conf
     sed -i 's@^#LoadModule mpm_worker_module@LoadModule mpm_worker_module@' ${apache_install_dir}/conf/httpd.conf
+    # 验证worker模式是否生效呢
     if ! ${apache_install_dir}/bin/httpd -V | grep -q 'worker.c'; then
       echo "${CFAILURE}Failed to enable worker mode! ${CEND}"
       exit 1

--- a/include/apache.sh
+++ b/include/apache.sh
@@ -106,7 +106,6 @@ Install_Apache() {
   elif [ "${apache_mpm_option}" == '3' ]; then
     sed -ri 's@^(LoadModule.*mod_mpm_event.so)@#\1@' ${apache_install_dir}/conf/httpd.conf
     sed -i 's@^#LoadModule mpm_worker_module@LoadModule mpm_worker_module@' ${apache_install_dir}/conf/httpd.conf
-    # 验证worker模式是否生效
     if ! ${apache_install_dir}/bin/httpd -V | grep -q 'worker.c'; then
       echo "${CFAILURE}Failed to enable worker mode! ${CEND}"
       exit 1

--- a/include/caddy.sh
+++ b/include/caddy.sh
@@ -30,7 +30,12 @@ Install_Caddy() {
   . /etc/profile
 
   #make soft link
-  # [ ! -L "/usr/local/bin/caddy" ] && ln -s ${caddy_install_dir}/bin/caddy /usr/local/bin/caddy
+  # 在用户创建部分后添加
+  sed -i "s@User=caddy@User=${run_user}@" /lib/systemd/system/caddy.service
+  sed -i "s@Group=caddy@Group=${run_group}@" /lib/systemd/system/caddy.service
+  
+  # 在PATH配置部分后添加软链接
+  [ ! -L "/usr/local/bin/caddy" ] && ln -s ${caddy_install_dir}/bin/caddy /usr/local/bin/caddy
 
   #move caddyfile to /usr/local/caddy/conf
   [ ! -d "${caddy_install_dir}/conf" ] && mkdir -p ${caddy_install_dir}/conf

--- a/include/check_download.sh
+++ b/include/check_download.sh
@@ -84,6 +84,11 @@ checkDownload() {
     1)
       echo "Download tomcat 10..."
       src_url=${mirror_link}/apache/tomcat/v${tomcat10_ver}/apache-tomcat-${tomcat10_ver}.tar.gz && Download_src
+      if [ ! -e "apache-tomcat-${tomcat10_ver}.tar.gz" ] || \
+         [ "$(md5sum apache-tomcat-${tomcat10_ver}.tar.gz | awk '{print $1}')" != "${tomcat10_md5}" ]; then
+        echo "Download failed or checksum mismatch"
+        exit 1
+      fi
       ;;
     2)
       echo "Download tomcat 9..."

--- a/include/pecl_xdebug.sh
+++ b/include/pecl_xdebug.sh
@@ -14,7 +14,7 @@ Install_pecl_xdebug() {
     phpExtensionDir=$(${php_install_dir}/bin/php-config --extension-dir)
     PHP_detail_ver=$(${php_install_dir}/bin/php-config --version)
     PHP_main_ver=${PHP_detail_ver%.*}
-    if [[ "${PHP_main_ver}" =~ ^7.[0-4]$|^80$ ]]; then
+    if [[ "${PHP_main_ver}" =~ ^7.[0-4]$|^8.[0-2]$ ]]; then
       if [[ "${PHP_main_ver}" =~ ^7.[0-1]$ ]]; then
         src_url=https://pecl.php.net/get/xdebug-${xdebug_oldver}.tgz && Download_src
         tar xzf xdebug-${xdebug_oldver}.tgz

--- a/include/tomcat-10.sh
+++ b/include/tomcat-10.sh
@@ -127,3 +127,15 @@ EOF
   service tomcat start
   popd > /dev/null
 }
+
+1. 在安装前添加JDK版本检查：
+   if [ "$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d. -f1)" -lt 11 ]; then
+     echo "Tomcat 10.1 requires JDK 11 or higher"
+     exit 1
+   fi
+
+2. 在启动服务前添加JAVA_HOME验证：
+   if [ -z "${JAVA_HOME}" ]; then
+     echo "JAVA_HOME environment variable is not set"
+     exit 1
+   fi


### PR DESCRIPTION
- 用户配置问题 ：caddy.service文件中指定了User=caddy和Group=caddy，但安装脚本caddy.sh中创建的用户是${run_user}和${run_group}，两者不一致导致服务启动失败。
- PATH环境变量问题 ：安装脚本虽然修改了/etc/profile添加了PATH，但没有创建/usr/local/bin/caddy的软链接，导致caddy命令无法直接调用。